### PR TITLE
Goreport badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/samurang87/availabot.svg?branch=master)](https://travis-ci.org/samurang87/availabot)
 [![Coverage Status](https://coveralls.io/repos/github/samurang87/availabot/badge.svg?branch=master)](https://coveralls.io/github/samurang87/availabot?branch=master)
+[![Go Report](https://goreportcard.com/badge/github.com/samurang87/availabot)](https://goreportcard.com/report/github.com/samurang87/availabot)]
 
 # availabot
 Telegram bot to check calendar availability


### PR DESCRIPTION
Having this badge is a bit more relaxed than failing the build on linter warnings.
Fixes #6 