### PR TITLE
Calculate the next free evenings based on FreeBusy calendars

### DIFF
--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -112,18 +112,18 @@ func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 		log.Fatalf("Unable to retrieve calendar Client %v", err)
 	}
 
-	t := t0.UTC().Format(time.RFC3339)
+	t := t0.Format(time.RFC3339)
 
-	t1 := t0.Add(time.Duration(168)*time.Hour).UTC().Format(time.RFC3339)
+	t1 := t0.Add(time.Duration(168) * time.Hour).Format(time.RFC3339)
 
 	fbri := calendar.FreeBusyRequestItem{Id: "primary"}
 
-	query := &calendar.FreeBusyRequest {
+	query := &calendar.FreeBusyRequest{
 		CalendarExpansionMax: 2,
-		Items: []*calendar.FreeBusyRequestItem{&fbri},
-		TimeMin: t,
-		TimeMax: t1,
-		}
+		Items:                []*calendar.FreeBusyRequestItem{&fbri},
+		TimeMin:              t,
+		TimeMax:              t1,
+	}
 
 	freebusy, err := srv.Freebusy.Query(query).Do()
 

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -90,7 +90,7 @@ func saveToken(file string, token *oauth2.Token) {
 	json.NewEncoder(f).Encode(token)
 }
 
-func GetBusyCalendar() []*calendar.TimePeriod {
+func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 	ctx := context.Background()
 
 	b, err := ioutil.ReadFile("client_id.json")
@@ -112,9 +112,9 @@ func GetBusyCalendar() []*calendar.TimePeriod {
 		log.Fatalf("Unable to retrieve calendar Client %v", err)
 	}
 
-	t := time.Now().UTC().Format(time.RFC3339)
+	t := t0.UTC().Format(time.RFC3339)
 
-	t1 := time.Now().Add(time.Duration(50)*time.Hour).UTC().Format(time.RFC3339)
+	t1 := t0.Add(time.Duration(168)*time.Hour).UTC().Format(time.RFC3339)
 
 	fbri := calendar.FreeBusyRequestItem{Id: "primary"}
 
@@ -129,6 +129,18 @@ func GetBusyCalendar() []*calendar.TimePeriod {
 
 	freebusy_cal := freebusy.Calendars["primary"].Busy
 
-	return freebusy_cal
+	return t0, freebusy_cal
 
+}
+
+// GetNextThreeEvenings gets a freebusy calendar and a timezone and return the next three free evenings
+func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) []time.Time {
+
+	date_array:= make([]time.Time, 3)
+
+	for i:=0;i<3;i++ {
+		date_array[i] = time.Now()
+	}
+
+	return date_array
 }

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -127,9 +127,9 @@ func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 
 	freebusy, err := srv.Freebusy.Query(query).Do()
 
-	freebusy_cal := freebusy.Calendars["primary"].Busy
+	freebusyCal := freebusy.Calendars["primary"].Busy
 
-	return t0, freebusy_cal
+	return t0, freebusyCal
 
 }
 
@@ -178,10 +178,10 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 		for _, busySlot := range c {
 
-			start_time, _ := time.Parse(time.RFC3339, busySlot.Start)
-			end_time, _ := time.Parse(time.RFC3339, busySlot.End)
+			startTime, _ := time.Parse(time.RFC3339, busySlot.Start)
+			endTime, _ := time.Parse(time.RFC3339, busySlot.End)
 
-			if ! (end_time.Before(eveningStart) || start_time.After(eveningEnd)) {
+			if ! (endTime.Before(eveningStart) || startTime.After(eveningEnd)) {
 
 				isFree = false
 				break

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -127,6 +127,10 @@ func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 
 	freebusy, err := srv.Freebusy.Query(query).Do()
 
+	if err != nil {
+		panic(err)
+	}
+
 	freebusyCal := freebusy.Calendars["primary"].Busy
 
 	return t0, freebusyCal
@@ -161,7 +165,6 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 	}
 
-
 	for _, eveningStart := range nextSevenDays {
 
 		eveningEnd := time.Date(
@@ -178,8 +181,17 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 		for _, busySlot := range c {
 
-			startTime, _ := time.Parse(time.RFC3339, busySlot.Start)
-			endTime, _ := time.Parse(time.RFC3339, busySlot.End)
+			startTime, err := time.Parse(time.RFC3339, busySlot.Start) // FIXME check error here
+
+			if err != nil {
+				panic(err)
+			}
+
+			endTime, err := time.Parse(time.RFC3339, busySlot.End)
+
+			if err != nil {
+				panic(err)
+			}
 
 			if ! (endTime.Before(eveningStart) || startTime.After(eveningEnd)) {
 

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -181,7 +181,7 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 		for _, busySlot := range c {
 
-			startTime, err := time.Parse(time.RFC3339, busySlot.Start) // FIXME check error here
+			startTime, err := time.Parse(time.RFC3339, busySlot.Start)
 
 			if err != nil {
 				panic(err)

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -129,7 +129,6 @@ func GetBusyCalendar(t0 time.Time) (start time.Time, cal []*calendar.TimePeriod,
 	}
 
 	freebusy, err := srv.Freebusy.Query(query).Do()
-
 	if err != nil {
 		log.Println("Error in executing query to get freebusy calendar")
 		return start, nil, err
@@ -148,9 +147,7 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 	if t.Hour() < 19 {
 		startDate = time.Date(t.Year(), t.Month(), t.Day(), 19, 0, 0, 0, t.Location())
-
 	} else {
-
 		startDate = time.Date(t.Year(), t.Month(), t.Day()+1, 19, 0, 0, 0, t.Location())
 	}
 
@@ -159,11 +156,8 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 	for day := 0; day <= 6; day++ {
 
 		if day == 0 {
-
 			nextSevenDays[day] = startDate
-
 		} else {
-
 			nextSevenDays[day] = nextSevenDays[day-1].Add(time.Duration(24) * time.Hour)
 		}
 
@@ -186,14 +180,14 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 		for _, busySlot := range c {
 
 			startTime, err := time.Parse(time.RFC3339, busySlot.Start)
-
 			if err != nil {
+				log.Printf("Unable to parse start time, got this error: %v", err)
 				return nil, err
 			}
 
 			endTime, err := time.Parse(time.RFC3339, busySlot.End)
-
 			if err != nil {
+				log.Printf("Unable to parse end time, got this error: %v", err)
 				return nil, err
 			}
 
@@ -204,13 +198,10 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 		}
 
 		if isFree {
-
 			free = append(free, eveningStart)
-
 		}
 
 		if len(free) == 3 {
-
 			break
 		}
 

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -193,7 +193,7 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 				panic(err)
 			}
 
-			if ! (endTime.Before(eveningStart) || startTime.After(eveningEnd)) {
+			if !(endTime.Before(eveningStart) || startTime.After(eveningEnd)) {
 
 				isFree = false
 				break
@@ -214,8 +214,6 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 
 	}
 
-
 	return
 
 }
-

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -136,11 +136,56 @@ func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 // GetNextThreeEvenings gets a freebusy calendar and a timezone and return the next three free evenings
 func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) []time.Time {
 
-	date_array:= make([]time.Time, 3)
+	date_array := make([]time.Time, 3)
 
-	for i:=0;i<3;i++ {
+	// if time is less than 19
+
+	// start from tomorrow
+
+	// otherwise from today
+
+	// calculate a map of days 165 hours from now, all False
+
+	// for each busy slot
+
+	// update the map if it makes the evening busy
+
+	// add to the result list the first three ones
+
+	for i := 0; i < 3; i++ {
 		date_array[i] = time.Now()
 	}
 
 	return date_array
+
+}
+
+func checkIfBusyEvening(slot *calendar.TimePeriod) (date time.Time, isBusy bool) {
+
+	// if the event starts between 19 and 23:59
+
+	start_time, _ := time.Parse(time.RFC3339, slot.Start)
+	end_time, _ := time.Parse(time.RFC3339, slot.End)
+
+	evening_start := time.Date(
+		start_time.Year(),
+		start_time.Month(),
+		start_time.Day(),
+		19,
+		0,
+		0,
+		0,
+		start_time.Location())
+
+	if (start_time.Hour() >= 19 && start_time.Hour() <= 23) ||
+		(end_time.Hour() >= 19 && end_time.Hour() <= 23) ||
+		end_time.Day() > start_time.Day() {
+
+		return evening_start, true
+
+	} else {
+
+		return evening_start, false
+	}
+
 }

--- a/calendar_checker/calendar_checker.go
+++ b/calendar_checker/calendar_checker.go
@@ -138,7 +138,7 @@ func GetBusyCalendar(t0 time.Time) (time.Time, []*calendar.TimePeriod) {
 }
 
 // GetNextThreeEvenings gets a freebusy calendar and a timezone and return the next three free evenings
-func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Time) {
+func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Time, err error) {
 
 	var startDate time.Time
 
@@ -184,13 +184,13 @@ func GetNextThreeEvenings(t time.Time, c []*calendar.TimePeriod) (free []time.Ti
 			startTime, err := time.Parse(time.RFC3339, busySlot.Start)
 
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 
 			endTime, err := time.Parse(time.RFC3339, busySlot.End)
 
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 
 			if !(endTime.Before(eveningStart) || startTime.After(eveningEnd)) {

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -1,9 +1,9 @@
 package calendar_checker
 
 import (
+	"google.golang.org/api/calendar/v3"
 	"testing"
 	"time"
-	"google.golang.org/api/calendar/v3"
 )
 
 func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
@@ -13,15 +13,15 @@ func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
 
 	firstSlot := calendar.TimePeriod{
 		Start: "2018-02-15T16:04:05+01:00",
-		End: "2018-02-15T17:04:05+01:00",
+		End:   "2018-02-15T17:04:05+01:00",
 	}
 
 	secondSlot := calendar.TimePeriod{
 		Start: "2018-02-16T18:04:05+01:00",
-		End: "2018-02-16T21:04:05+01:00",
+		End:   "2018-02-16T21:04:05+01:00",
 	}
 
-	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&firstSlot, &secondSlot}}
+	calendarExample := calendar.FreeBusyCalendar{Busy: []*calendar.TimePeriod{&firstSlot, &secondSlot}}
 
 	freeDates := make([]time.Time, 3)
 	freeDates[0], _ = time.Parse(time.RFC3339, "2018-02-15T19:00:00+01:00")
@@ -30,7 +30,6 @@ func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
 
 	// execution
 	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
-
 
 	// check
 	for i, want := range freeDates {
@@ -51,10 +50,10 @@ func TestGetNextThreeEveningsFromEvening(t *testing.T) {
 
 	onlySlot := calendar.TimePeriod{
 		Start: "2018-02-16T18:04:05+01:00",
-		End: "2018-02-16T21:04:05+01:00",
+		End:   "2018-02-16T21:04:05+01:00",
 	}
 
-	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
+	calendarExample := calendar.FreeBusyCalendar{Busy: []*calendar.TimePeriod{&onlySlot}}
 
 	freeDates := make([]time.Time, 3)
 	freeDates[0], _ = time.Parse(time.RFC3339, "2018-02-17T19:00:00+01:00")
@@ -63,7 +62,6 @@ func TestGetNextThreeEveningsFromEvening(t *testing.T) {
 
 	// execution
 	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
-
 
 	// check
 	for i, want := range freeDates {
@@ -77,21 +75,20 @@ func TestGetNextThreeEveningsFromEvening(t *testing.T) {
 
 }
 
-func TestGetNextThreeEveningsButYouAreOnVacation (t *testing.T) {
+func TestGetNextThreeEveningsButYouAreOnVacation(t *testing.T) {
 
 	// fixture
 	afternoonStart, _ := time.Parse(time.RFC3339, "2018-02-15T20:04:05+01:00")
 
 	onlySlot := calendar.TimePeriod{
 		Start: "2018-02-16T18:04:05+01:00",
-		End: "2018-02-28T21:04:05+01:00",
+		End:   "2018-02-28T21:04:05+01:00",
 	}
 
-	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
+	calendarExample := calendar.FreeBusyCalendar{Busy: []*calendar.TimePeriod{&onlySlot}}
 
 	// execution
 	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
-
 
 	// check
 	if len(result) != 0 {

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -84,25 +84,19 @@ func TestGetNextThreeEveningsButYouAreOnVacation (t *testing.T) {
 
 	onlySlot := calendar.TimePeriod{
 		Start: "2018-02-16T18:04:05+01:00",
-		End: "2018-02-2816T21:04:05+01:00",
+		End: "2018-02-28T21:04:05+01:00",
 	}
 
-	calendar_example := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
-
-	free_dates := make([]time.Time, 3)
+	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
 
 	// execution
-	result := GetNextThreeEvenings(afternoonStart, calendar_example.Busy)
+	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
 
 
 	// check
-	for i, want := range free_dates {
+	if len(result) != 0 {
+		t.Errorf("It should not have returned any free evenings! But it returned %v", result)
 
-		got := result[i]
-
-		if want != got {
-			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
-		}
 	}
 
 }

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -1,21 +1,45 @@
 package calendar_checker
 
 import (
-	"fmt"
 	"testing"
 	"time"
+	"google.golang.org/api/calendar/v3"
 )
 
 func TestGetNextThreeEvenings(t *testing.T) {
 
-	afternoon_start, err := time.Parse(time.RFC3339, "2018-02-15T15:04:05+01:00")
+	// fixture
+	afternoon_start, _ := time.Parse(time.RFC3339, "2018-02-15T15:04:05+01:00")
 
-	if err == nil {
-		fmt.Println(GetNextThreeEvenings(afternoon_start))
-	} else {
-		fmt.Println(err)
+	first_slot := calendar.TimePeriod{
+		Start: "2018-02-15T16:04:05+01:00",
+		End: "2018-02-15T17:04:05+01:00",
 	}
 
+	second_slot := calendar.TimePeriod{
+		Start: "2018-02-16T18:04:05+01:00",
+		End: "2018-02-16T21:04:05+01:00",
+	}
 
+	calendar_example := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&first_slot, &second_slot}}
+
+	free_dates := make([]time.Time, 3)
+	free_dates[0], _ = time.Parse(time.RFC3339, "2018-02-15T19:00:00+01:00")
+	free_dates[1], _ = time.Parse(time.RFC3339, "2018-02-17T19:00:00+01:00")
+	free_dates[2], _ = time.Parse(time.RFC3339, "2018-02-18T19:00:00+01:00")
+
+	// execution
+	result := GetNextThreeEvenings(afternoon_start, calendar_example.Busy)
+
+
+	// check
+	for i, want := range(free_dates) {
+		
+		got := result[i]
+
+		if want != got {
+			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
+		}
+	}
 
 }

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -29,7 +29,11 @@ func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
 	freeDates[2], _ = time.Parse(time.RFC3339, "2018-02-18T19:00:00+01:00")
 
 	// execution
-	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+	result, err := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+
+	if err != nil {
+		panic(err)
+	}
 
 	// check
 	for i, want := range freeDates {
@@ -61,7 +65,11 @@ func TestGetNextThreeEveningsFromEvening(t *testing.T) {
 	freeDates[2], _ = time.Parse(time.RFC3339, "2018-02-19T19:00:00+01:00")
 
 	// execution
-	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+	result, err := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+
+	if err != nil {
+		panic(err)
+	}
 
 	// check
 	for i, want := range freeDates {
@@ -88,7 +96,12 @@ func TestGetNextThreeEveningsButYouAreOnVacation(t *testing.T) {
 	calendarExample := calendar.FreeBusyCalendar{Busy: []*calendar.TimePeriod{&onlySlot}}
 
 	// execution
-	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+	result, err := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+
+
+	if err != nil {
+		panic(err)
+	}
 
 	// check
 	if len(result) != 0 {

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -33,8 +33,8 @@ func TestGetNextThreeEvenings(t *testing.T) {
 
 
 	// check
-	for i, want := range(free_dates) {
-		
+	for i, want := range free_dates {
+
 		got := result[i]
 
 		if want != got {

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -36,7 +36,7 @@ func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
 
 		got := result[i]
 
-		if want != got {
+		if want.Unix() != got.Unix() {
 			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
 		}
 	}
@@ -68,7 +68,7 @@ func TestGetNextThreeEveningsFromEvening(t *testing.T) {
 
 		got := result[i]
 
-		if want != got {
+		if want.Unix() != got.Unix() {
 			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
 		}
 	}

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -1,9 +1,21 @@
 package calendar_checker
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
 
-func TestFoo(t *testing.T) {
-	if true != true {
-		t.Errorf("everyting is false!")
+func TestGetNextThreeEvenings(t *testing.T) {
+
+	afternoon_start, err := time.Parse(time.RFC3339, "2018-02-15T15:04:05+01:00")
+
+	if err == nil {
+		fmt.Println(GetNextThreeEvenings(afternoon_start))
+	} else {
+		fmt.Println(err)
 	}
+
+
+
 }

--- a/calendar_checker/calendar_checker_test.go
+++ b/calendar_checker/calendar_checker_test.go
@@ -6,30 +6,93 @@ import (
 	"google.golang.org/api/calendar/v3"
 )
 
-func TestGetNextThreeEvenings(t *testing.T) {
+func TestGetNextThreeEveningsFromAfternoon(t *testing.T) {
 
 	// fixture
-	afternoon_start, _ := time.Parse(time.RFC3339, "2018-02-15T15:04:05+01:00")
+	afternoonStart, _ := time.Parse(time.RFC3339, "2018-02-15T15:04:05+01:00")
 
-	first_slot := calendar.TimePeriod{
+	firstSlot := calendar.TimePeriod{
 		Start: "2018-02-15T16:04:05+01:00",
 		End: "2018-02-15T17:04:05+01:00",
 	}
 
-	second_slot := calendar.TimePeriod{
+	secondSlot := calendar.TimePeriod{
 		Start: "2018-02-16T18:04:05+01:00",
 		End: "2018-02-16T21:04:05+01:00",
 	}
 
-	calendar_example := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&first_slot, &second_slot}}
+	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&firstSlot, &secondSlot}}
 
-	free_dates := make([]time.Time, 3)
-	free_dates[0], _ = time.Parse(time.RFC3339, "2018-02-15T19:00:00+01:00")
-	free_dates[1], _ = time.Parse(time.RFC3339, "2018-02-17T19:00:00+01:00")
-	free_dates[2], _ = time.Parse(time.RFC3339, "2018-02-18T19:00:00+01:00")
+	freeDates := make([]time.Time, 3)
+	freeDates[0], _ = time.Parse(time.RFC3339, "2018-02-15T19:00:00+01:00")
+	freeDates[1], _ = time.Parse(time.RFC3339, "2018-02-17T19:00:00+01:00")
+	freeDates[2], _ = time.Parse(time.RFC3339, "2018-02-18T19:00:00+01:00")
 
 	// execution
-	result := GetNextThreeEvenings(afternoon_start, calendar_example.Busy)
+	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+
+
+	// check
+	for i, want := range freeDates {
+
+		got := result[i]
+
+		if want != got {
+			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
+		}
+	}
+
+}
+
+func TestGetNextThreeEveningsFromEvening(t *testing.T) {
+
+	// fixture
+	afternoonStart, _ := time.Parse(time.RFC3339, "2018-02-15T20:04:05+01:00")
+
+	onlySlot := calendar.TimePeriod{
+		Start: "2018-02-16T18:04:05+01:00",
+		End: "2018-02-16T21:04:05+01:00",
+	}
+
+	calendarExample := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
+
+	freeDates := make([]time.Time, 3)
+	freeDates[0], _ = time.Parse(time.RFC3339, "2018-02-17T19:00:00+01:00")
+	freeDates[1], _ = time.Parse(time.RFC3339, "2018-02-18T19:00:00+01:00")
+	freeDates[2], _ = time.Parse(time.RFC3339, "2018-02-19T19:00:00+01:00")
+
+	// execution
+	result := GetNextThreeEvenings(afternoonStart, calendarExample.Busy)
+
+
+	// check
+	for i, want := range freeDates {
+
+		got := result[i]
+
+		if want != got {
+			t.Errorf("For date n. %v, wanted %v, got %v", i, want, got)
+		}
+	}
+
+}
+
+func TestGetNextThreeEveningsButYouAreOnVacation (t *testing.T) {
+
+	// fixture
+	afternoonStart, _ := time.Parse(time.RFC3339, "2018-02-15T20:04:05+01:00")
+
+	onlySlot := calendar.TimePeriod{
+		Start: "2018-02-16T18:04:05+01:00",
+		End: "2018-02-2816T21:04:05+01:00",
+	}
+
+	calendar_example := calendar.FreeBusyCalendar{Busy:[]*calendar.TimePeriod{&onlySlot}}
+
+	free_dates := make([]time.Time, 3)
+
+	// execution
+	result := GetNextThreeEvenings(afternoonStart, calendar_example.Busy)
 
 
 	// check

--- a/main.go
+++ b/main.go
@@ -10,7 +10,11 @@ func main() {
 
 	_, busy := calendar_checker.GetBusyCalendar(time.Now())
 
-	threeFree := calendar_checker.GetNextThreeEvenings(time.Now(), busy)
+	threeFree, err := calendar_checker.GetNextThreeEvenings(time.Now(), busy)
+
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Println(threeFree)
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,11 @@ import (
 
 func main() {
 
-	_, busy := calendar_checker.GetBusyCalendar(time.Now())
+	_, busy, err := calendar_checker.GetBusyCalendar(time.Now())
+
+	if err != nil {
+		panic(err)
+	}
 
 	threeFree, err := calendar_checker.GetNextThreeEvenings(time.Now(), busy)
 

--- a/main.go
+++ b/main.go
@@ -1,19 +1,17 @@
 package main
 
 import (
-	"fmt"
 	"github.com/samurang87/availabot/calendar_checker"
 	"time"
+	"fmt"
 )
 
 func main() {
 
 	_, busy := calendar_checker.GetBusyCalendar(time.Now())
 
-	for _, slot := range busy {
+	threeFree := calendar_checker.GetNextThreeEvenings(time.Now(), busy)
 
-		fmt.Println(slot.Start)
-		fmt.Println(slot.End)
+	fmt.Println(threeFree)
 
-	}
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"fmt"
 	"github.com/samurang87/availabot/calendar_checker"
-	"fmt")
+	"time"
+)
 
 func main() {
 
-	fmt.Println(calendar_checker.GetBusyCalendar())
+	_, busy := calendar_checker.GetBusyCalendar(time.Now())
 
+	for _, slot := range busy {
+
+		fmt.Println(slot.Start)
+		fmt.Println(slot.End)
+
+	}
 }


### PR DESCRIPTION
A minimal implementation of a request for availability returns the first three free evenings within the next seven days.